### PR TITLE
Rp2040 devicetree support

### DIFF
--- a/dts/arm/raspberrypi/rp2040.dtsi
+++ b/dts/arm/raspberrypi/rp2040.dtsi
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2021 Joep Buruma
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <arm/armv6-m.dtsi>
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/i2c/i2c.h>
+
+/ {
+	aliases {
+	};
+
+	chosen {
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m0+";
+			reg = <0>;
+		};
+
+		cpu1: cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m0+";
+			reg = <1>;
+		};
+
+	};
+
+	sram0: memory@20000000 {
+		compatible = "mmio-sram";
+		reg = <0x20000000 DT_SIZE_K(256)>;
+	};
+
+	soc {
+
+		flash-ctrl: flashctrl@18000000 {
+			compatible = "snps,designware-apb-ssi";
+			reg = <0x18000000 0xfc>;
+			label = "FLASH_CTRL";
+			interrupts = <6 0>;
+			interrupt-names = "xip_irq";
+
+			flash0: flash@10000000 {
+				label = "FLASH_0";
+			};
+		};
+
+		gclk: gclk@40008000 {
+			compatible = "raspberrypi,gclk";
+			#clock-cells = <7>;
+			reg = <0x40008000 0xc8>;
+			interrupts = <17  0>;
+			interrupt-names = "clocks_irq";
+		};
+
+		iobank0: iobank@40014000 {
+			compatible = "raspberrypi,gpio";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x40014000 0x190>;
+			interrupts = <13 0>, <15 0>, <16 0>;
+			interrupt-names = "io_irq_bank0", "sio_irq_proc0", "sio_irq_proc1";
+			label = "IOBANK_0";
+		};
+
+		iobank_qspi: iobank@18000000 {
+			status = "disabled";
+			compatible = "raspberrypi,gpio-qspi";
+			reg = <0x18000000 0xfc>;
+			interrupts = <14 0>;
+			interrupt-names = "io_irq_qspi";
+			label = "IOBANK_QSPI";
+		};
+
+		dma0: dma@50000000 {
+			status = "disabled";
+			compatible = "raspberrypi,dma";
+			interrupts = <11 0>, <12 0>;
+			interrupt-names = "dma_irq_0", "dma_irq_1";
+			reg = <0x50000000 0xac8>;
+			label = "DMA_0";
+		};
+
+		pio0: pio@50200000 {
+			compatible = "raspberrypi,pio";
+			status = "disabled";
+			reg <0x50200000 0x144> ;
+			interrupts = <7 0>, <8 0>;
+			interrupt-names = "pio0_irq_0", "pio0_irq_1";
+		};
+
+		pio1: pio@50300000 {
+			compatible = "raspberrypi,pio";
+			status = "disabled";
+			reg <0x50300000 0x144> ;
+			interrupts = <9 0>, <10 0>;
+			interrupt-names = "pio1_irq_0", "pio1_irq_1";
+		};
+
+		usb0: usb@50110000 {
+			compatible = "raspberrypi,usb";
+			status = "disabled";
+			reg = <0x50110000 0x9c>;
+			interrupts = <5 0>;
+			interrupt-names = "usbctrl_irq";
+		};
+
+		uart0: uart@40034000 {
+			status = "disabled";
+			compatible = "arm,pl011";
+			reg = <0x40034000 DT_SIZE_K(4)>;
+			interrupts = <20  3>;
+			interrupt-names = "uart0_irq";
+			label = "UART_0";
+		};
+
+		uart1: uart@40038000 {
+			status = "disabled";
+			compatible = "arm,pl011";
+			reg = <0x40038000 DT_SIZE_K(4)>;
+			interrupts = <21  3>;
+			interrupt-names = "uart1_irq";
+			label = "UART_1";
+		};
+
+		i2c0: i2c@40044000 {
+			status = "disabled";
+			compatible = "snps,designware-apb-i2c";
+			reg = <0x40044000 0x100>;
+			label = "I2C_0";
+			interrupts = <23 0>;
+			interrupt-names = "i2c0_irq";
+		};
+
+		i2c1: i2c@40048000 {
+			status = "disabled";
+			compatible = "snps,designware-apb-i2c";
+			reg = <0x40048000 0x100>;
+			label = "I2C_1";
+			interrupts = <24 0>;
+			interrupt-names = "i2c1_irq";
+		};
+
+		spi0: spi@4003c000 {
+			status = "disabled";
+			compatible = "arm,pl022";
+			reg = <0x4003c000 0x1000>;
+			label = "SPI_0";
+			interrupts = <18 0>;
+			interrupt-names = "spi0_irq";
+		};
+
+		spi1: spi@40040000 {
+			status = "disabled";
+			compatible = "arm,pl022";
+			reg = <0x40040000 0x1000>;
+			label = "SPI_1";
+			interrupts = <19 0>;
+			interrupt-names = "spi1_irq";
+		};
+
+		pwm: pwm@40050000 {
+			status = "disabled";
+			compatible = "raspberrypi,pwm";
+			reg = <0x40050000 0xb4>;
+			interrupts = <4 0>;
+			interrupt-names = "pwm_irq_wrap";
+			label = "PWM";
+		};
+
+		tim0: timer@40054000 {
+			status = "disabled";
+			compatible = "raspberrypi,timer";
+			reg = <0x40054000 0x44>;
+			interrupts = <0 0>, <1 0>, <2 0>, <3 0>;
+			interrupt-names = "timer_irq_1",
+			                  "timer_irq_2",
+			                  "timer_irq_3",
+			                  "timer_irq_4";
+			label = "TIM_0";
+		};
+
+		wdog0: watchdog@40058000 {
+			status = "disabled";
+			compatible = "raspberrypi,watchdog";
+			reg = <0x40058000 0x30>;
+			label = "WATCHDOG_0";
+		};
+
+		rtc: rtc@4005c000 {
+			status = "disabled";
+			compatible = "raspberrypi,rtc";
+			reg = <0x4005c000 0x30>;
+			interrupts = <25 3>;
+			interrupt-names = "rtc_irq";
+			label = "RTC";
+		};
+
+		adc0: adc@4004c000 {
+			status = "disabled";
+			compatible = "raspberrypi,adc";
+			reg = <0x4004c000 0x24>;
+			label = "ADC0";
+			interrupts = <22 0>;
+			interrupt-names = "adc_irq_fio";
+		};
+
+	};
+
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <2>;
+};

--- a/soc/arm/raspberrypi/Kconfig
+++ b/soc/arm/raspberrypi/Kconfig
@@ -11,6 +11,6 @@ config SOC_FAMILY
 	string
 	default "raspberry_pi_rp"
 
-source "soc/arm/raspberry_pi/*/Kconfig.soc"
+source "soc/arm/raspberrypi/*/Kconfig.soc"
 
 endif # SOC_FAMILY_RASPBERRY_PI

--- a/soc/arm/raspberrypi/Kconfig.defconfig
+++ b/soc/arm/raspberrypi/Kconfig.defconfig
@@ -5,6 +5,6 @@
 
 if SOC_FAMILY_RASPBERRY_PI
 
-source "soc/arm/raspberry_pi/*/Kconfig.defconfig.series"
+source "soc/arm/raspberrypi/*/Kconfig.defconfig.series"
 
 endif # SOC_FAMILY_RASPBERRY_PI

--- a/soc/arm/raspberrypi/Kconfig.soc
+++ b/soc/arm/raspberrypi/Kconfig.soc
@@ -3,4 +3,4 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-source "soc/arm/raspberry_pi/*/Kconfig.series"
+source "soc/arm/raspberrypi/*/Kconfig.series"

--- a/soc/arm/raspberrypi/rp20/Kconfig.defconfig.series
+++ b/soc/arm/raspberrypi/rp20/Kconfig.defconfig.series
@@ -5,7 +5,7 @@
 
 if SOC_SERIES_RP20XX
 
-source "soc/arm/raspberry_pi/rp20/Kconfig.defconfig.rp20*"
+source "soc/arm/raspberrypi/rp20/Kconfig.defconfig.rp20*"
 
 config SOC_SERIES
 	default "rp2040"


### PR DESCRIPTION
This adds the devicetree for the RP2040.

Since this is a new SoC this still needs a lot of devicetree bindings, namely:

- [ ] GPIO
- [ ] SPI (arm pl022)
- [ ] I2C (designware apb i2c)
- [ ] Programmable IO
- [ ] clocks
- [ ] flash control / xip control
- [ ] dma
- [ ] USB
- [ ] PWM
- [ ] Timers
- [ ] watchdog
- [ ] RTC

The UART peripheral already has a devicetree binding and accompanying driver.